### PR TITLE
[client] Retain proper sort order in packs

### DIFF
--- a/client/src/draft/draft_types.ts
+++ b/client/src/draft/draft_types.ts
@@ -37,6 +37,8 @@ export interface DraftPlayer {
 export interface DraftCard {
   id: number;
   definition: MtgCard;
+  /** The index position of this card in its original pack */
+  sourcePackIndex: number,
   draftedBy: DraftedBy | null;
 }
 

--- a/client/src/parse/parseInitialState.ts
+++ b/client/src/parse/parseInitialState.ts
@@ -66,7 +66,8 @@ export function parseInitialState(srcData: SourceData): DraftState {
 
 function parsePack(srcPack: SourceCard[]) {
   const pack = [] as DraftCard[];
-  for (const srcPick of srcPack) {
+  for (let i = 0; i < srcPack.length; i++) {
+    const srcPick = srcPack[i];
     pack.push({
       id: nextCardId++,
       definition: {
@@ -75,6 +76,7 @@ function parsePack(srcPack: SourceCard[]) {
         collector_number: srcPick.number,
         tags: srcPick.tags.split(", "),
       },
+      sourcePackIndex: i,
       draftedBy: null,
     });
   }

--- a/client/src/ui/table/CardGrid.vue
+++ b/client/src/ui/table/CardGrid.vue
@@ -12,7 +12,7 @@
         class="selected-pack"
         >
       <div
-          v-for="card in selectedPack.cards"
+          v-for="card in selectedPack"
           :key="card.id"
           class="card"
           >
@@ -67,19 +67,27 @@ export default Vue.extend({
       return null;
     },
 
-    selectedPack(): CardContainer | null {
+    selectedPack(): DraftCard[] | null {
+      let pack: CardContainer | null = null;
+
       if (this.selection == null) {
         return null;
       } else if (this.selection.type == 'pack') {
-        return checkNotNil(
-            this.$tstore.state.draft.packs.get(this.selection.id));
+        pack =
+            checkNotNil(this.$tstore.state.draft.packs.get(this.selection.id));
       } else {
         const player = this.$tstore.state.draft.seats[this.selection.id];
         if (player.queuedPacks.length > 0) {
-          return player.queuedPacks[0];
-        } else {
-          return null;
+          pack = player.queuedPacks[0];
         }
+      }
+
+      if (pack != null) {
+        return pack.cards
+            .concat()
+            .sort((a, b) => a.sourcePackIndex - b.sourcePackIndex);
+      } else {
+        return null;
       }
     },
 


### PR DESCRIPTION
Prevoiusly, when going backwards and forwards in time, packs would
move around. Use a sort key so they always show in the right order.