### PR TITLE
Fix replay skipping pick 1 of packs 2 and 3

### DIFF
--- a/client/src/draft/mutate.ts
+++ b/client/src/draft/mutate.ts
@@ -2,7 +2,18 @@ import { DraftState, CardContainer, CardPack } from "./DraftState";
 import { checkNotNil } from '../util/checkNotNil';
 import { TimelineEvent, TimelineAction, ActionMovePack, PackLocation, PACK_LOCATION_UNUSED, PACK_LOCATION_DEAD } from './TimelineEvent';
 
+const DEBUG = false;
+
 export function commitTimelineEvent(event: TimelineEvent, state: DraftState) {
+  if (DEBUG) {
+    console.log(
+        'APPLYING EVENT:',
+        event.id,
+        event.round,
+        event.roundEpoch,
+        event.associatedSeat,
+        event.actions.map(a => a.type));
+  }
   try {
     for (const action of event.actions) {
       applyAction(action, state);

--- a/client/src/parse/TimelineGenerator.ts
+++ b/client/src/parse/TimelineGenerator.ts
@@ -98,7 +98,7 @@ export class TimelineGenerator {
       }
       this._eventIndex--;
       playerData.currentRound++;
-      playerData.nextEpoch = 0;
+      playerData.nextEpoch = 1;
       outEvent.roundEpoch = 0;
 
       const nextPack = checkNotNil(seat.unopenedPacks[0]);


### PR DESCRIPTION
- Change the "open the next pack" event to have its own roundEpoch
  number (0).
- Change the way synchronized mode decides when to stop applying
  events. Always apply "open pack" events when going either direction.