### PR TITLE
Basic deck builder UI (issue #45)

### DIFF
--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,15 +1,21 @@
 import Vue from 'vue';
 import VueRouter from 'vue-router';
+import DeckBuilderScreen from '../ui/DeckBuilderScreen.vue';
 import Home from '../ui/Home.vue';
 
 Vue.use(VueRouter);
 
 const routes = [
   {
-    path: '/*',
+    path: '/',
     name: 'Home',
     component: Home,
   },
+  {
+    path: '/deckbuilder',
+    name: 'DeckBuilderScreen',
+    component: DeckBuilderScreen,
+  }
   // TODO: Figure out route splitting in the future
   // {
   //   path: '/about',

--- a/client/src/state/store.ts
+++ b/client/src/state/store.ts
@@ -1,12 +1,12 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import {SelectedView} from './selection';
-import {DraftState, MtgCard} from '../draft/DraftState';
-import {TimelineEvent} from '../draft/TimelineEvent';
-import {buildEmptyDraftState} from '../draft/buildEmptyDraftState';
-import {commitTimelineEvent, rollbackTimelineEvent} from '../draft/mutate';
-import {cloneDraftState} from '../draft/cloneDraftState';
-import {find} from '../util/collection';
+import { SelectedView } from './selection';
+import { DraftState, MtgCard } from '../draft/DraftState';
+import { TimelineEvent } from '../draft/TimelineEvent';
+import { buildEmptyDraftState } from '../draft/buildEmptyDraftState';
+import { commitTimelineEvent, rollbackTimelineEvent } from '../draft/mutate';
+import { cloneDraftState } from '../draft/cloneDraftState';
+import { find } from '../util/collection';
 
 Vue.use(Vuex);
 
@@ -244,6 +244,18 @@ const store = new Vuex.Store({
         source[move.targetColumnIndex]
             .splice(targetCardIndex, 0, card);
       }
+    },
+
+    initDeck(state: RootState) {
+      if (state.selection !== null && state.selection.type === 'seat') {
+        const cards = state.draft.seats[state.selection.id].player.picks.cards.map(
+            card => card.definition);
+        Vue.set(store.state.decks, state.selection.id, {
+          sideboard: [cards, [], [], [], [], [], []],
+          maindeck: [[], [], [], [], [], [], []],
+        });
+      }
+
     },
 
   },

--- a/client/src/state/store.ts
+++ b/client/src/state/store.ts
@@ -34,6 +34,7 @@ export interface CardMove {
   sourceCardIndex: number,
   sourceMaindeck: boolean,
   targetColumnIndex: number,
+  targetCardIndex: number,
   targetMaindeck: boolean,
 }
 
@@ -213,21 +214,35 @@ const store = new Vuex.Store({
     },
 
     moveCard(state: RootState, move: CardMove) {
+      let card: MtgCard;
+      let source: CardColumn[];
+      if (move.sourceMaindeck) {
+        source = state.decks[move.deckIndex].maindeck;
+      } else {
+        source = state.decks[move.deckIndex].sideboard;
+      }
       if (move.sourceMaindeck !== move.targetMaindeck
           || move.sourceColumnIndex !== move.targetColumnIndex) {
-        let card: MtgCard;
-        if (move.sourceMaindeck) {
-          [card] = state.decks[move.deckIndex].maindeck[move.sourceColumnIndex]
-              .splice(move.sourceCardIndex, 1);
-        } else {
-          [card] = state.decks[move.deckIndex].sideboard[move.sourceColumnIndex]
-              .splice(move.sourceCardIndex, 1);
-        }
+        [card] = source[move.sourceColumnIndex]
+            .splice(move.sourceCardIndex, 1);
+        let target: CardColumn[];
         if (move.targetMaindeck) {
-          state.decks[move.deckIndex].maindeck[move.targetColumnIndex].push(card);
+          target = state.decks[move.deckIndex].maindeck;
         } else {
-          state.decks[move.deckIndex].sideboard[move.targetColumnIndex].push(card);
+          target = state.decks[move.deckIndex].sideboard;
         }
+        target[move.targetColumnIndex]
+            .splice(move.targetCardIndex, 0, card);
+      } else if (move.sourceCardIndex !== move.targetCardIndex
+          && move.sourceCardIndex !== move.targetCardIndex + 1) {
+        [card] = source[move.sourceColumnIndex]
+            .splice(move.sourceCardIndex, 1);
+        const targetCardIndex =
+            (move.targetCardIndex < move.sourceCardIndex)
+                ? move.targetCardIndex
+                : move.targetCardIndex - 1;
+        source[move.targetColumnIndex]
+            .splice(targetCardIndex, 0, card);
       }
     },
 

--- a/client/src/ui/DeckBuilderScreen.vue
+++ b/client/src/ui/DeckBuilderScreen.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="_home">
+  <div class="_deck-builder-screen">
     <div class="main">
       <DraftTable class="table"/>
       <DeckBuilder class="deckbuilder"/>
@@ -12,8 +12,8 @@
 
   import DraftTable from './table/DraftTable.vue';
   import DeckBuilder from './deckbuilder/DeckBuilder.vue';
-  import {parseDraft} from "../parse/parseDraft";
-  import {FAKE_DATA_03} from "../fake_data/FAKE_DATA_03";
+  import { parseDraft } from "../parse/parseDraft";
+  import { FAKE_DATA_03 } from "../fake_data/FAKE_DATA_03";
 
   export default Vue.extend({
     name: 'DeckBuilderScreen',
@@ -45,7 +45,7 @@
 </script>
 
 <style scoped>
-  ._home {
+  ._deck-builder-screen {
     height: 100%;
     display: flex;
     flex-direction: column;

--- a/client/src/ui/DeckBuilderScreen.vue
+++ b/client/src/ui/DeckBuilderScreen.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="_home">
+    <div class="main">
+      <DraftTable class="table"/>
+      <DeckBuilder class="deckbuilder"/>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+
+  import DraftTable from './table/DraftTable.vue';
+  import DeckBuilder from './deckbuilder/DeckBuilder.vue';
+  import {parseDraft} from "../parse/parseDraft";
+  import {FAKE_DATA_03} from "../fake_data/FAKE_DATA_03";
+
+  export default Vue.extend({
+    name: 'DeckBuilderScreen',
+
+    components: {
+      DraftTable,
+      DeckBuilder,
+    },
+
+    created() {
+      const srcData = this.getServerPayload();
+      const draft = parseDraft(srcData);
+      this.$tstore.commit('initDraft', draft);
+      this.$tstore.commit('goTo', this.$tstore.state.events.length);
+    },
+
+    methods: {
+      getServerPayload() {
+        if (window.DraftString != undefined) {
+          console.log('Found server payload, loading!');
+          return JSON.parse(window.DraftString);
+        } else {
+          console.log(`Couldn't find server payload, falling back to default...`);
+          return FAKE_DATA_03;
+        }
+      },
+    }
+  })
+</script>
+
+<style scoped>
+  ._home {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .main {
+    display: flex;
+    flex: 1;
+    flex-direction: row;
+    overflow: hidden;
+  }
+
+  .table {
+    width: 300px;
+    flex: 0 0 auto;
+  }
+
+  .deckbuilder {
+    flex: 1;
+  }
+</style>

--- a/client/src/ui/deckbuilder/DeckBuilder.vue
+++ b/client/src/ui/deckbuilder/DeckBuilder.vue
@@ -3,19 +3,21 @@
     <DeckBuilderSection
         :columns="sideboard"
         :deckIndex="deckIndex"
-        :maindeck="false"/>
+        :maindeck="false"
+    />
     <DeckBuilderSection
         :columns="maindeck"
         :deckIndex="deckIndex"
-        :maindeck="true"/>
+        :maindeck="true"
+    />
   </div>
 </template>
 
 <script lang="ts">
   import Vue from 'vue';
-  import {SelectedView} from "../../state/selection.js";
-  import {DraftSeat} from "../../draft/DraftState.js";
-  import {CardColumn, Deck} from "../../state/store.js";
+  import { SelectedView } from "../../state/selection.js";
+  import { DraftSeat } from "../../draft/DraftState.js";
+  import { CardColumn, Deck } from "../../state/store.js";
   import DeckBuilderSection from "./DeckBuilderSection.vue";
 
   export default Vue.extend({
@@ -44,11 +46,7 @@
           return null;
         } else {
           if (!this.$tstore.state.decks[this.selectedSeat.position]) {
-            const cards = this.selectedSeat.player.picks.cards.map(card => card.definition);
-            this.$set(this.$tstore.state.decks, this.selectedSeat.position, {
-              sideboard: [cards, [], [], [], [], [], []],
-              maindeck: [[], [], [], [], [], [], []],
-            });
+            this.$tstore.commit("initDeck");
           }
           return this.$tstore.state.decks[this.selectedSeat.position];
         }

--- a/client/src/ui/deckbuilder/DeckBuilder.vue
+++ b/client/src/ui/deckbuilder/DeckBuilder.vue
@@ -4,12 +4,12 @@
         :columns="sideboard"
         :deckIndex="deckIndex"
         :maindeck="false"
-    />
+        />
     <DeckBuilderSection
         :columns="maindeck"
         :deckIndex="deckIndex"
         :maindeck="true"
-    />
+        />
   </div>
 </template>
 

--- a/client/src/ui/deckbuilder/DeckBuilder.vue
+++ b/client/src/ui/deckbuilder/DeckBuilder.vue
@@ -1,0 +1,72 @@
+<template>
+  <div>
+    <DeckBuilderSection
+        :columns="sideboard"
+        :deckIndex="deckIndex"
+        :maindeck="false"/>
+    <DeckBuilderSection
+        :columns="maindeck"
+        :deckIndex="deckIndex"
+        :maindeck="true"/>
+  </div>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import {SelectedView} from "../../state/selection.js";
+  import {DraftSeat} from "../../draft/DraftState.js";
+  import {CardColumn, Deck} from "../../state/store.js";
+  import DeckBuilderSection from "./DeckBuilderSection.vue";
+
+  export default Vue.extend({
+    name: 'DeckBuilder',
+
+    components: {
+      DeckBuilderSection,
+    },
+
+    computed: {
+      selection(): SelectedView | null {
+        return this.$tstore.state.selection;
+      },
+
+      selectedSeat(): DraftSeat | null {
+        return this.selection == null || this.selection.type == 'pack' ? null :
+            this.$tstore.state.draft.seats[this.selection.id];
+      },
+
+      deckIndex(): number {
+        return this.selectedSeat === null ? 0 : this.selectedSeat.position;
+      },
+
+      deck(): Deck | null {
+        if (this.selectedSeat === null) {
+          return null;
+        } else {
+          if (!this.$tstore.state.decks[this.selectedSeat.position]) {
+            const cards = this.selectedSeat.player.picks.cards.map(card => card.definition);
+            this.$set(this.$tstore.state.decks, this.selectedSeat.position, {
+              sideboard: [cards, [], [], [], [], [], []],
+              maindeck: [[], [], [], [], [], [], []],
+            });
+          }
+          return this.$tstore.state.decks[this.selectedSeat.position];
+        }
+      },
+
+      sideboard(): CardColumn[] {
+        return this.deck ? this.deck.sideboard : [];
+      },
+
+      maindeck(): CardColumn[] {
+        return this.deck ? this.deck.maindeck : [];
+      },
+    },
+
+    methods: {},
+  });
+</script>
+
+<style scoped>
+
+</style>

--- a/client/src/ui/deckbuilder/DeckBuilderColumn.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderColumn.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-      class="column"
+      class="_column"
       @dragover="dragOver"
       @dragleave="dragEnd"
       @dragend="dragEnd"
@@ -8,14 +8,14 @@
   >
     <div
         v-for="(card, index) in column"
+        :key="card.set + '|' + card.collector_number"
+        @dragstart="dragStart($event, index)"
         class="card"
     >
       <img
           class="card-img"
           :src="getImageSrc(card)"
           :alt="card.name"
-          :data-index="index"
-          @dragstart="dragStart"
       />
     </div>
   </div>
@@ -23,8 +23,8 @@
 
 <script lang="ts">
   import Vue from 'vue';
-  import {MtgCard} from "../../draft/DraftState.js";
-  import {CardColumn, CardMove} from "../../state/store.js";
+  import { MtgCard } from "../../draft/DraftState.js";
+  import { CardColumn, CardMove } from "../../state/store.js";
 
   export default Vue.extend({
     name: 'DeckBuilderColumn',
@@ -54,14 +54,13 @@
         }
       },
 
-      dragStart(e: DragEvent) {
+      dragStart(e: DragEvent, index: number) {
         if (e.dataTransfer) {
-          const targetElement = <HTMLElement>e.target;
           const cardMove: CardMove = {
             deckIndex: this.deckIndex,
             sourceMaindeck: this.maindeck,
             sourceColumnIndex: this.columnIndex,
-            sourceCardIndex: Number(targetElement.dataset["index"]),
+            sourceCardIndex: index,
             targetMaindeck: false,
             targetColumnIndex: 0,
             targetCardIndex: 0,
@@ -134,7 +133,7 @@
 
 <style scoped>
 
-  .column {
+  ._column {
     padding: 10px;
     width: 204px;
   }

--- a/client/src/ui/deckbuilder/DeckBuilderColumn.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderColumn.vue
@@ -5,18 +5,18 @@
       @dragleave="dragEnd"
       @dragend="dragEnd"
       @drop="drop"
-  >
+      >
     <div
         v-for="(card, index) in column"
         :key="card.set + '|' + card.collector_number"
         @dragstart="dragStart($event, index)"
         class="card"
-    >
+        >
       <img
           class="card-img"
           :src="getImageSrc(card)"
           :alt="card.name"
-      />
+          />
     </div>
   </div>
 </template>

--- a/client/src/ui/deckbuilder/DeckBuilderColumn.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderColumn.vue
@@ -1,0 +1,132 @@
+<template>
+  <div
+      class="column"
+      @dragover="dragOver"
+      @dragleave="dragEnd"
+      @dragend="dragEnd"
+      @drop="drop"
+  >
+    <div
+        v-for="(card, index) in column"
+        class="card"
+    >
+      <img
+          class="card-img"
+          :src="getImageSrc(card)"
+          :alt="card.name"
+          :data-index="index"
+          @dragstart="dragStart"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import {MtgCard} from "../../draft/DraftState.js";
+  import {CardColumn, CardMove} from "../../state/store.js";
+
+  export default Vue.extend({
+    name: 'DeckBuilderColumn',
+
+    props: {
+      column: {
+        type: Array as () => CardColumn
+      },
+      columnIndex: {
+        type: Number
+      },
+      deckIndex: {
+        type: Number
+      },
+      maindeck: {
+        type: Boolean
+      }
+    },
+
+    methods: {
+      getImageSrc(card: MtgCard): string {
+        if (process.env.NODE_ENV == 'development') {
+          return `http://api.scryfall.com/cards/${card.set}/`
+              + `${card.collector_number}?format=image&version=normal`;
+        } else {
+          return `/proxy/${card.set}/${card.collector_number}`;
+        }
+      },
+
+      dragStart(e: DragEvent) {
+        if (e.dataTransfer) {
+          const targetElement = <HTMLElement>e.target;
+          const cardMove: CardMove = {
+            deckIndex: this.deckIndex,
+            sourceMaindeck: this.maindeck,
+            sourceColumnIndex: this.columnIndex,
+            sourceCardIndex: Number(targetElement.dataset["index"]),
+            targetMaindeck: false,
+            targetColumnIndex: 0,
+          };
+          e.dataTransfer.setData("text/plain", JSON.stringify(cardMove));
+          e.dataTransfer.effectAllowed = "move";
+        }
+      },
+
+      dragOver(e: DragEvent) {
+        e.preventDefault();
+        if (e.dataTransfer) {
+          e.dataTransfer.dropEffect = "move";
+          this.$el.classList.add("columnDrop");
+        }
+      },
+
+      dragEnd(e: DragEvent) {
+        e.preventDefault();
+        if (e.dataTransfer) {
+          this.$el.classList.remove("columnDrop");
+        }
+      },
+
+      drop(e: DragEvent) {
+        e.preventDefault();
+        if (e.dataTransfer) {
+          const cardMove: CardMove = JSON.parse(e.dataTransfer.getData("text/plain"));
+          // TODO find correct index based on event target
+          this.$tstore.commit("moveCard",
+              {
+                ...cardMove,
+                targetMaindeck: this.maindeck,
+                targetColumnIndex: this.columnIndex,
+              });
+        }
+        this.$el.classList.remove("columnDrop");
+      }
+    },
+  });
+</script>
+
+<style scoped>
+
+  .column {
+    padding: 10px;
+    width: 204px;
+  }
+
+  .columnDrop {
+    background: #ddd;
+  }
+
+  .card {
+    height: 30px;
+    overflow-y: visible;
+  }
+
+  .card-img {
+    width: 200px;
+    height: 279px;
+    border: 2px solid transparent;
+    border-radius: 10px;
+  }
+
+  .card-img:hover {
+    border-color: #bbd;
+  }
+</style>

--- a/client/src/ui/deckbuilder/DeckBuilderSection.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderSection.vue
@@ -12,7 +12,7 @@
 
 <script lang="ts">
   import Vue from 'vue'
-  import {CardColumn} from "../../state/store.js";
+  import { CardColumn } from "../../state/store.js";
   import DeckBuilderColumn from "./DeckBuilderColumn.vue";
 
   export default Vue.extend({

--- a/client/src/ui/deckbuilder/DeckBuilderSection.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderSection.vue
@@ -6,7 +6,7 @@
         :deckIndex="deckIndex"
         :maindeck="maindeck"
         :columnIndex="index"
-    />
+        />
   </div>
 </template>
 

--- a/client/src/ui/deckbuilder/DeckBuilderSection.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderSection.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="section">
+    <DeckBuilderColumn
+        v-for="(column, index) in columns"
+        :column="column"
+        :deckIndex="deckIndex"
+        :maindeck="maindeck"
+        :columnIndex="index"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue'
+  import {CardColumn} from "../../state/store.js";
+  import DeckBuilderColumn from "./DeckBuilderColumn.vue";
+
+  export default Vue.extend({
+    name: 'DeckBuilderSection',
+
+    components: {
+      DeckBuilderColumn
+    },
+
+    props: {
+      columns: {
+        type: Array as () => CardColumn[]
+      },
+      deckIndex: {
+        type: Number
+      },
+      maindeck: {
+        type: Boolean
+      }
+    },
+
+  });
+</script>
+
+<style scoped>
+  .section {
+    display: flex;
+    flex-direction: row;
+    height: 50%;
+    overflow-y: scroll;
+  }
+
+  .section:first-child {
+    border-bottom: 3px solid #555;
+  }
+</style>


### PR DESCRIPTION
Allows drag-and-drop of cards between columns in sideboard and maindeck.

Doesn't:
- initialize columns to a reasonable state
- let you re-sort based on CMC or anything
- let you drag multiple cards at once
- persist changes to the server