### PR TITLE
Clean up routing a bit

### DIFF
--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,28 +1,20 @@
 import Vue from 'vue';
 import VueRouter, { RouteConfig } from 'vue-router';
-import DeckBuilderScreen from '../ui/DeckBuilderScreen.vue';
-import Home from '../ui/Home.vue';
+import DeckBuilder from '../ui/DeckBuilder.vue';
+import Replay from '../ui/Replay.vue';
 
 Vue.use(VueRouter);
 
+// See https://github.com/pillarjs/path-to-regexp/ for route matching language
+
 const routes = [
   {
-    path: '/replay/:draftId/',
-    component: Home,
-  },
-  {
-    path: '/replay/:draftId/:timelineMode/:eventIndex/',
-    component: Home,
-  },
-  {
-    path:
-        '/replay/:draftId/:timelineMode/:eventIndex/:selectionType/:locationId',
-    component: Home,
+    path: `/replay/:draftId(\\d+)/:param*`,
+    component: Replay,
   },
   {
     path: '/deckbuilder/*',
-    name: 'DeckBuilderScreen',
-    component: DeckBuilderScreen,
+    component: DeckBuilder,
   }
   // TODO: Figure out route splitting in the future
   // {

--- a/client/src/state/store.ts
+++ b/client/src/state/store.ts
@@ -52,18 +52,14 @@ const store = new Vuex.Store({
     initDraft(
         state: CoreState,
         payload: {
-          id: number,
-          draft: {
-            state: DraftState,
-            events: TimelineEvent[],
-          },
+          state: DraftState,
+          events: TimelineEvent[],
         }
     ) {
-      initialDraftState = cloneDraftState(payload.draft.state);
+      initialDraftState = cloneDraftState(payload.state);
 
-      state.draftId = payload.id;
-      state.draft = cloneDraftState(payload.draft.state);
-      state.events = payload.draft.events;
+      state.draft = cloneDraftState(payload.state);
+      state.events = payload.events;
       state.eventPos = 0;
       state.selection = {
         type: 'seat',
@@ -150,6 +146,10 @@ const store = new Vuex.Store({
         default:
           throw new Error(`Unrecognized timeMode: ${state.timeMode}`);
       }
+    },
+
+    setDraftId(state: CoreState, draftId: number) {
+      state.draftId = draftId;
     },
 
     setTimeMode(state: CoreState, mode: TimeMode) {

--- a/client/src/ui/DeckBuilder.vue
+++ b/client/src/ui/DeckBuilder.vue
@@ -2,7 +2,7 @@
   <div class="_deck-builder-screen">
     <div class="main">
       <DeckBuilderPlayerSelector class="player-selector" />
-      <DeckBuilder class="deckbuilder" />
+      <DeckBuilderMain class="deckbuilder" />
     </div>
   </div>
 </template>
@@ -10,7 +10,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import DeckBuilder from './deckbuilder/DeckBuilder.vue';
+import DeckBuilderMain from './deckbuilder/DeckBuilderMain.vue';
 import DeckBuilderPlayerSelector from './deckbuilder/DeckBuilderPlayerSelector.vue';
 import { parseDraft } from "../parse/parseDraft";
 import { MtgCard, DraftCard } from '../draft/DraftState';
@@ -19,10 +19,8 @@ import { commitTimelineEvent } from '../draft/mutate';
 import { getServerPayload } from '../parse/getServerPayload';
 
 export default Vue.extend({
-  name: 'DeckBuilderScreen',
-
   components: {
-    DeckBuilder,
+    DeckBuilderMain,
     DeckBuilderPlayerSelector,
   },
 

--- a/client/src/ui/Replay.vue
+++ b/client/src/ui/Replay.vue
@@ -33,22 +33,19 @@ export default Vue.extend({
     const srcData = getServerPayload();
     const draft = parseDraft(srcData);
 
-    this.$tstore.commit('initDraft', {
-      id: parseInt(this.$route.params['draftId']),
-      draft,
-    });
+    this.$tstore.commit('initDraft', draft);
 
     if (this.$tstore.state.draft.isComplete) {
       this.$tstore.commit('setTimeMode', 'synchronized');
       this.$tstore.commit('goTo', this.$tstore.state.events.length);
     }
 
-    applyReplayUrlState(this.$tstore, this.$route.params);
+    applyReplayUrlState(this.$tstore, this.$route);
   },
 
   watch: {
     $route(to, from) {
-      applyReplayUrlState(this.$tstore, this.$route.params);
+      applyReplayUrlState(this.$tstore, this.$route);
     },
   }
 });

--- a/client/src/ui/deckbuilder/DeckBuilderMain.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderMain.vue
@@ -22,8 +22,6 @@ import DeckBuilderSection from "./DeckBuilderSection.vue";
 import { DeckBuilderState, CardColumn, Deck } from '../../state/DeckBuilderModule.js';
 
 export default Vue.extend({
-  name: 'DeckBuilder',
-
   components: {
     DeckBuilderSection,
   },


### PR DESCRIPTION
Rename Home -> Replay
Rename DraftBuilderScreen -> DeckBuilder

Change Replay so it only has one entry in the routing. Modify the
URL parsing so we just accept arbitrary params after /:draftId and do
the parsing manually.

If we can get it so that each root component only has one entry in the
routes then we can, in theory, do auto-code splitting. As soon as I figure
out how that works.