### PR TITLE
Tweak deckbuilder CSS for better scrolling behavior

### DIFF
--- a/client/src/ui/deckbuilder/DeckBuilderColumn.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderColumn.vue
@@ -136,6 +136,8 @@ export default Vue.extend({
 ._column {
   padding: 10px;
   width: 204px;
+  flex: 0 0 auto;
+  padding-bottom: 250px;
 }
 
 .columnDrop {

--- a/client/src/ui/deckbuilder/DeckBuilderMain.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderMain.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="_deck-builder-main">
     <DeckBuilderSection
         class="maindeck"
         :columns="sideboard"
@@ -7,6 +7,7 @@
         :maindeck="false"
         />
     <DeckBuilderSection
+        class="sideboard"
         :columns="maindeck"
         :deckIndex="state.selectedSeat"
         :maindeck="true"
@@ -49,7 +50,18 @@ export default Vue.extend({
 </script>
 
 <style scoped>
+._deck-builder-main {
+  display: flex;
+  flex-direction: column;
+  overflow-x: scroll;
+}
+
 .maindeck {
+  flex: 3 0 0;
   border-bottom: 1px solid #EAEAEA;
+}
+
+.sideboard {
+  flex: 2 0 0;
 }
 </style>

--- a/client/src/ui/deckbuilder/DeckBuilderPlayerSelector.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderPlayerSelector.vue
@@ -39,6 +39,8 @@ export default Vue.extend({
 
 .player {
   padding: 10px 10px;
+  cursor: default;
+  user-select: none;
 }
 
 .player.selected {

--- a/client/src/ui/deckbuilder/DeckBuilderSection.vue
+++ b/client/src/ui/deckbuilder/DeckBuilderSection.vue
@@ -1,13 +1,15 @@
 <template>
-  <div class="section">
-    <DeckBuilderColumn
-        v-for="(column, index) in columns"
-        :key="index"
-        :column="column"
-        :deckIndex="deckIndex"
-        :maindeck="maindeck"
-        :columnIndex="index"
-        />
+  <div class="_deck-builder-section">
+    <div class="column-cnt">
+      <DeckBuilderColumn
+          v-for="(column, index) in columns"
+          :key="index"
+          :column="column"
+          :deckIndex="deckIndex"
+          :maindeck="maindeck"
+          :columnIndex="index"
+          />
+    </div>
   </div>
 </template>
 
@@ -39,10 +41,12 @@ export default Vue.extend({
 </script>
 
 <style scoped>
-.section {
+._deck-builder-section {
+  overflow: scroll;
+}
+
+.column-cnt {
   display: flex;
   flex-direction: row;
-  height: 50%;
-  overflow-y: scroll;
 }
 </style>


### PR DESCRIPTION
Messes with a bunch of deckbuilder's CSS to enable
(a) Horizontal scrolling when not all columns fit on the screen
(b) Make all columns fill the full height, even if one of them is
    so tall that scrolling is necessary