### PR TITLE
Fix error when clicking on cards at end of draft

### DIFF
--- a/client/src/router/url_manipulation.ts
+++ b/client/src/router/url_manipulation.ts
@@ -112,6 +112,9 @@ function parseUrl(route: Route) {
           id: value,
         }
         break;
+      case '':
+        // No params, ignore this stub
+        break;
       default:
         console.warn('Unrecognized URL param:', param);
         break;

--- a/client/src/ui/table/CardGrid.vue
+++ b/client/src/ui/table/CardGrid.vue
@@ -190,7 +190,9 @@ function findPick(
       }
     }
   } else {
-    for (let i = currentIndex; i >= 0; i--) {
+    // We could be at currentIndex = length if at the end of the draft
+    const startingPos = Math.min(currentIndex, events.length - 1);
+    for (let i = startingPos; i >= 0; i--) {
       const event = events[i];
       if (containsPick(event, cardId)) {
         return {


### PR DESCRIPTION
If the event index is at the end, then previously clicking on any
drafted cards would result in an error.