### PR TITLE
[replay] Show draft name & current pack and pick

### DIFF
--- a/client/src/draft/DraftState.ts
+++ b/client/src/draft/DraftState.ts
@@ -3,7 +3,6 @@ export interface DraftState {
   seats: DraftSeat[];
   unusedPacks: CardPack[];
   packs: Map<number, CardContainer>;
-  isComplete: boolean;
 }
 
 export interface DraftSeat {

--- a/client/src/draft/buildEmptyDraftState.ts
+++ b/client/src/draft/buildEmptyDraftState.ts
@@ -5,6 +5,5 @@ export function buildEmptyDraftState(): DraftState {
     seats: [],
     unusedPacks: [],
     packs: new Map(),
-    isComplete: false,
-  }
+  };
 }

--- a/client/src/parse/TimelineGenerator.ts
+++ b/client/src/parse/TimelineGenerator.ts
@@ -13,6 +13,7 @@ export class TimelineGenerator {
   private _eventIndex = 0;
   private _nextTimelineId = 0;
   private _playerTrackers = [] as PlayerTracker[];
+  private _isComplete = false;
 
   generate(state: DraftState, events: SourceEvent[]) {
     this.initialize(cloneDraftState(state), events);
@@ -25,7 +26,7 @@ export class TimelineGenerator {
   }
 
   isComplete() {
-    return this._state.isComplete;
+    return this._isComplete;
   }
 
   private initialize(state: DraftState, events: SourceEvent[]) {
@@ -35,6 +36,7 @@ export class TimelineGenerator {
     this._eventIndex = 0;
     this._nextTimelineId = 0;
     this._playerTrackers = [];
+    this._isComplete = false;
 
     // Fill out our player trackers
     for (const seat of this._state.seats) {
@@ -51,7 +53,7 @@ export class TimelineGenerator {
 
   next(): boolean {
     if (this._eventIndex >= this._srcEvents.length) {
-      this._state.isComplete = this.isDraftComplete();
+      this._isComplete = this.isDraftComplete();
       return false;
     }
     const srcEvent = this._srcEvents[this._eventIndex];

--- a/client/src/parse/parseDraft.ts
+++ b/client/src/parse/parseDraft.ts
@@ -6,11 +6,22 @@ import { TimelineEvent } from '../draft/TimelineEvent';
 
 export function parseDraft(
   sourceData: SourceData
-): { state: DraftState, events: TimelineEvent[] } {
+): ParsedDraft {
   const state = parseInitialState(sourceData);
   const generator = new TimelineGenerator();
   const events = generator.generate(state, sourceData.events);
-  // HACK: This should probably just be an event at the end of the event stream
-  state.isComplete = generator.isComplete();
-  return { state, events };
+
+  return {
+    name: sourceData.name,
+    isComplete: generator.isComplete(),
+    state,
+    events,
+  };
+}
+
+export interface ParsedDraft {
+  name: string,
+  isComplete: boolean,
+  state: DraftState,
+  events: TimelineEvent[],
 }

--- a/client/src/parse/parseInitialState.ts
+++ b/client/src/parse/parseInitialState.ts
@@ -12,7 +12,6 @@ export function parseInitialState(srcData: SourceData): DraftState {
     seats: [],
     unusedPacks: [],
     packs: packMap,
-    isComplete: false,
   };
 
   for (const [i, srcSeat] of srcData.seats.entries()) {

--- a/client/src/state/util/getNextPickEventForSelectedPlayer.ts
+++ b/client/src/state/util/getNextPickEventForSelectedPlayer.ts
@@ -1,0 +1,18 @@
+import { CoreState } from '../store';
+import { TimelineEvent } from '../../draft/TimelineEvent';
+import { isPickEvent } from './isPickEvent';
+
+export function getNextPickEventForSelectedPlayer(
+  state: CoreState,
+): TimelineEvent | null {
+  const seatId = state.selection?.id;
+  let pickEvent: TimelineEvent | null = null;
+  for (let i = state.eventPos; i < state.events.length; i++) {
+    const event = state.events[i];
+    if (event.associatedSeat == seatId && isPickEvent(event)) {
+      pickEvent = event;
+      break;
+    }
+  }
+  return pickEvent;
+}

--- a/client/src/state/util/isPickEvent.ts
+++ b/client/src/state/util/isPickEvent.ts
@@ -1,0 +1,6 @@
+import { TimelineEvent } from '../../draft/TimelineEvent';
+import { find } from '../../util/collection';
+
+export function isPickEvent(event: TimelineEvent): boolean {
+  return find(event.actions, { type: 'move-card' }) != -1;
+}

--- a/client/src/ui/Replay.vue
+++ b/client/src/ui/Replay.vue
@@ -37,6 +37,7 @@ export default Vue.extend({
     this.$tstore.commit('setTimeMode', 'synchronized');
     this.$tstore.commit('goTo', this.$tstore.state.events.length);
 
+    document.title = `Replay of ${this.$tstore.state.draftName}`;
     applyReplayUrlState(this.$tstore, this.$route);
   },
 

--- a/client/src/ui/table/ControlsRow.vue
+++ b/client/src/ui/table/ControlsRow.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="_controls-row">
-    <div class="start"></div>
+    <div class="start">
+      <div class="draft-name">{{ state.draftName }}</div>
+    </div>
     <div class="center">
       <button @click="onStartClick" class="playback-btn">« Start</button>
       <button @click="onPrevClick" class="playback-btn">‹ Prev</button>
@@ -18,6 +20,12 @@
           >
         Synchronize timeline
       </label>
+      <button class="location-btn">
+        <div class="location-p1">{{ firstLocationLabel }}</div>
+        <div v-if="secondLocationLabel" class="location-p2">
+          {{ secondLocationLabel }}
+        </div>
+      </button>
     </div>
   </div>
 </template>
@@ -25,6 +33,10 @@
 <script lang="ts">
 import Vue from 'vue'
 import { navTo } from '../../router/url_manipulation';
+import { CoreState } from '../../state/store';
+import { getNextPickEventForSelectedPlayer } from '../../state/util/getNextPickEventForSelectedPlayer';
+import { TimelineEvent } from '../../draft/TimelineEvent';
+
 export default Vue.extend({
   computed: {
     synchronizeTimeline: {
@@ -36,7 +48,34 @@ export default Vue.extend({
         this.$tstore.commit('setTimeMode', value ? 'synchronized' : 'original');
         navTo(this.$tstore, this.$route, this.$router, {});
       }
-    }
+    },
+
+    state(): CoreState {
+      return this.$tstore.state;
+    },
+
+    nextPickEvent(): TimelineEvent | null {
+      return getNextPickEventForSelectedPlayer(this.state);
+    },
+
+    firstLocationLabel(): string {
+      const pickEvent = this.nextPickEvent;
+      if (pickEvent != null) {
+        return `Pack ${pickEvent.round}`;
+      } else if (this.state.eventPos >= this.state.events.length) {
+        return `End of draft`;
+      } else {
+        return `Event ${this.state.events[this.state.eventPos].id}`;
+      }
+    },
+
+    secondLocationLabel(): string | null {
+      if (this.nextPickEvent != null) {
+        return `Pick ${this.nextPickEvent.pick + 1}`;
+      } else {
+        return null;
+      }
+    },
   },
 
   methods: {
@@ -58,7 +97,7 @@ export default Vue.extend({
 
     onEndClick() {
       navTo(this.$tstore, this.$route, this.$router, {
-        eventIndex: this.$tstore.state.events.length,
+        eventIndex: this.state.events.length,
       });
     },
   },
@@ -77,6 +116,8 @@ export default Vue.extend({
 
 .start {
   flex: 1 0 0;
+  display: flex;
+  align-items: center;
 }
 
 .center {
@@ -102,4 +143,40 @@ export default Vue.extend({
 .synchronize-label {
   margin-left: 4px;
 }
+
+.draft-name {
+  color: #828282;
+}
+
+.location-btn {
+  padding: 6px 15px;
+  min-width: 150px;
+  text-align: left;
+  margin-left: 15px;
+  user-select: none;
+  cursor: default;
+  display: flex;
+  flex: 0 0 auto;
+
+  /* Override default button styling */
+  font-size: 100%;
+  font-family: inherit;
+  border: 1px solid #EAEAEA;
+  border-radius: 5px;
+}
+
+.location-btn:focus {
+  border-color: #D0D0D0;
+  outline: none;
+}
+
+.location-p1, .location-p2 {
+  flex: 1 0 0;
+  white-space: nowrap;
+}
+
+.location-p2 {
+  margin-left: 13px;
+}
+
 </style>

--- a/client/src/ui/table/DraftTable.vue
+++ b/client/src/ui/table/DraftTable.vue
@@ -33,7 +33,6 @@ export default Vue.extend({
 
   display: flex;
   flex-direction: column;
-  padding-top: 10px;
 
   border-right: 1px solid #EAEAEA;
 }


### PR DESCRIPTION
Adds the current draft name on the top left
Adds the current pack and pick on the top right

Eventually the pack&pick will be clickable to show a timeline scrubber
and the synchronized timeline checkbox will live there.