### PR TITLE
remove half-baked autopick functionality for #48

### DIFF
--- a/main.go
+++ b/main.go
@@ -760,13 +760,6 @@ func ServeDraft(w http.ResponseWriter, r *http.Request, userId int64) {
 		revealed = append(revealed, msg)
 	}
 	viewParam := GetViewParam(r, userId)
-	// Auto-pick the last card in the pack.
-	if len(myPack) == 1 {
-		cardId := myPack[0].Id
-		http.Redirect(w, r, fmt.Sprintf("/pick/%d%s", cardId, viewParam), http.StatusTemporaryRedirect)
-		return
-	}
-
 	t := template.Must(template.ParseFiles("draft.tmpl"))
 
 	data := DraftPageData{Picks: myPicks, Pack: myPack, DraftId: draftId, DraftName: draftName, Powers: powers2, Position: position, Revealed: revealed, ViewUrl: viewParam}


### PR DESCRIPTION
This doesn't work how I thought it did, and it's confusing to have it sometimes-autopick, so removing the modification I made. Will likely unassign #48 afterwards -- doPick() is hairy enough I'm not confident I can mess with it without breaking something or spending a lot of time manually testing things. Might take another crack at it after some of the SQL optimization / formatting work is taken care of, sorry for the churn.