### PR TITLE
[client] Add support for on-demand code loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ pkg/
 run.sh
 node_modules/
 /client/dist
+/client/stats.json
 static/dist

--- a/client/build_config/webpack.common.js
+++ b/client/build_config/webpack.common.js
@@ -25,8 +25,15 @@ module.exports = mode => {
     output: {
       // The all-important `path` field is specified in .dev and .prod
 
-      // Filename of compiled JS bundle(s)
+      // Our compiled entry point -- the thing we include as a script tag in
+      // our HTML. Right now we have just one entry point app, so this will be
+      // app.bundle.js
       filename: '[name].bundle.js',
+
+      // Our app is broken into chunks and loaded lazily when we need them. This
+      // specifies their filenames. The chunks themselves are specified in
+      // src/router/index.ts
+      chunkFilename: '[name].bundle.js',
 
       // URL route that the webserver will serve our output from
       publicPath: '/static/dist/',

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "start": "webpack-dev-server --config build_config/webpack.dev.js",
-    "build": "webpack --config build_config/webpack.prod.js",
+    "build": "webpack --config build_config/webpack.prod.js --progress --hide-modules",
+    "build-stats": "webpack --config build_config/webpack.prod.js --progress --profile --json > stats.json",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,11 +1,12 @@
 import Vue from 'vue';
 import VueRouter, { RouteConfig } from 'vue-router';
-import DeckBuilder from '../ui/DeckBuilder.vue';
-import Replay from '../ui/Replay.vue';
 
 Vue.use(VueRouter);
 
 // See https://github.com/pillarjs/path-to-regexp/ for route matching language
+
+// We use chunk splitting so that we only load the source for the route we're
+// looking at right now. That's what the webpackChunkName directive does below
 
 const routes = [
   // login
@@ -13,22 +14,14 @@ const routes = [
   // draft
   {
     path: `/replay/:draftId(\\d+)/:param*`,
-    component: Replay,
+    component: () =>
+        import(/* webpackChunkName: 'replay' */ '../ui/Replay.vue'),
   },
   {
     path: '/deckbuilder/*',
-    component: DeckBuilder,
+    component: () =>
+        import(/* webpackChunkName: 'deckbuilder' */ '../ui/DeckBuilder.vue'),
   }
-  // TODO: Figure out route splitting in the future
-  // {
-  //   path: '/about',
-  //   name: 'About',
-  //   // route level code-splitting
-  //   // this generates a separate chunk (about.[hash].js) for this route
-  //   // which is lazy-loaded when the route is visited.
-  //   component: () =>
-  //     import(/* webpackChunkName: 'about' */ '../ui/About.vue'),
-  // },
 ] as RouteConfig[];
 
 if (DEVELOPMENT) {


### PR DESCRIPTION
Previously we shipped a single JS bundle that contained all the code for
all routes. This is wasteful, since the user starts out just looking at
one route.

Now, webpack will output multiple compiled JS files and will load them
only when they are needed. See src/client/router/index.ts for where we
specify the routes that should be split apart.