### PR TITLE
Exclude pre-canned json blobs from production builds

### DIFF
--- a/client/build_config/webpack.prod.js
+++ b/client/build_config/webpack.prod.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 const merge = require('webpack-merge');
 
 const common = require('./webpack.common')('production');
@@ -20,4 +21,11 @@ module.exports = merge.smart(common, {
     // from.
     path: path.resolve(PROJECT_ROOT, 'static/dist'),
   },
+
+  plugins: [
+    new webpack.NormalModuleReplacementPlugin(
+      /src\/fake_data\/devReplayData\.ts$/,
+      './devReplayData.stub.ts',
+    ),
+  ],
 });

--- a/client/src/fake_data/FAKE_DATA_03.ts
+++ b/client/src/fake_data/FAKE_DATA_03.ts
@@ -1,4 +1,4 @@
-import {SourceData} from '../parse/SourceData';
+import { SourceData } from '../parse/SourceData';
 
 export const FAKE_DATA_03: SourceData = {
   "seats":[

--- a/client/src/fake_data/devReplayData.stub.ts
+++ b/client/src/fake_data/devReplayData.stub.ts
@@ -1,0 +1,7 @@
+import { SourceData } from '../parse/SourceData';
+
+/**
+ * This file replaces devReplayData.ts in production builds (see
+ * /build_config/webpack.prod.js)
+ */
+export const devReplayData: SourceData | null = null;

--- a/client/src/fake_data/devReplayData.ts
+++ b/client/src/fake_data/devReplayData.ts
@@ -1,0 +1,10 @@
+import { FAKE_DATA_03 } from './FAKE_DATA_03';
+import { SourceData } from '../parse/SourceData';
+
+/**
+ * Precanned data for use during local development
+ *
+ * This file is replaced bt devReplayData.stub.ts for production builds (see
+ * /build_config/webpack.prod.js).
+ */
+export const devReplayData: SourceData | null = FAKE_DATA_03;

--- a/client/src/parse/getServerPayload.ts
+++ b/client/src/parse/getServerPayload.ts
@@ -1,11 +1,14 @@
-import { FAKE_DATA_03 } from '../fake_data/FAKE_DATA_03';
+import { devReplayData } from '../fake_data/devReplayData';
+
 
 export function getServerPayload() {
   if (window.DraftString != undefined) {
     console.log('Found server payload, loading!');
     return JSON.parse(window.DraftString);
-  } else {
+  } else if (devReplayData != null) {
     console.log(`Couldn't find server payload, falling back to default...`);
-    return FAKE_DATA_03;
+    return devReplayData;
+  } else {
+    throw new Error(`No server payload found, but in a production build!`);
   }
 }


### PR DESCRIPTION
1. Hide usages of FAKE_DATA_03.ts behind devReplayData.ts
2. In production builds, replace devReplayData.ts with a stub version that
   doesn't load FAKE_DATA_03.ts.