### PR TITLE
Ensure we update state maps every time

### DIFF
--- a/client/src/draft/DraftState.ts
+++ b/client/src/draft/DraftState.ts
@@ -49,7 +49,14 @@ export interface DraftCard {
   definition: MtgCard;
   /** The index position of this card in its original pack */
   sourcePackIndex: number;
-  pickedIn: TimelineEvent[];
+  pickedIn: CardPick[];
+}
+
+export interface CardPick {
+  seat: number,
+  round: number,
+  pick: number,
+  eventId: number,
 }
 
 export interface MtgCard {

--- a/client/src/draft/cloneDraftState.ts
+++ b/client/src/draft/cloneDraftState.ts
@@ -1,40 +1,10 @@
-import { DraftState, CardContainer, PackContainer } from './DraftState';
+import { DraftState } from './DraftState';
+import { fillDraftStateMaps } from '../parse/fillDraftStateMaps';
 
 export function cloneDraftState(src: DraftState) {
   const clonedState: DraftState = JSON.parse(JSON.stringify(src));
 
-  clonedState.packs = new Map<number, CardContainer>();
-  clonedState.locations = new Map<number, PackContainer>();
-
-  registerLocation(clonedState, clonedState.unusedPacks);
-  registerLocation(clonedState, clonedState.deadPacks);
-
-  registerCardContainers(clonedState, clonedState.unusedPacks.packs);
-  registerCardContainers(clonedState, clonedState.deadPacks.packs);
-  for (const seat of clonedState.seats) {
-    registerCardContainers(clonedState, [seat.player.picks]);
-    registerCardContainers(clonedState, seat.queuedPacks.packs);
-    registerCardContainers(clonedState, seat.unopenedPacks.packs);
-
-    registerLocation(clonedState, seat.queuedPacks);
-    registerLocation(clonedState, seat.unopenedPacks);
-  }
+  fillDraftStateMaps(clonedState);
 
   return clonedState;
-}
-
-function registerLocation(
-    state: DraftState,
-    location: PackContainer,
-) {
-  state.locations.set(location.id, location);
-}
-
-function registerCardContainers(
-  state: DraftState,
-  containers: CardContainer[]
-) {
-  for (const container of containers) {
-    state.packs.set(container.id, container);
-  }
 }

--- a/client/src/parse/fillDraftStateMaps.ts
+++ b/client/src/parse/fillDraftStateMaps.ts
@@ -1,0 +1,32 @@
+import { DraftState, PackContainer, CardContainer } from '../draft/DraftState';
+
+export function fillDraftStateMaps(state: DraftState) {
+  state.locations = new Map();
+  state.packs = new Map();
+
+  registerLocation(state, state.unusedPacks);
+  registerLocation(state, state.deadPacks);
+
+  for (const seat of state.seats) {
+    registerCardContainers(state, [seat.player.picks]);
+    registerLocation(state, seat.queuedPacks);
+    registerLocation(state, seat.unopenedPacks);
+  }
+}
+
+function registerLocation(
+    state: DraftState,
+    location: PackContainer,
+) {
+  state.locations.set(location.id, location);
+  registerCardContainers(state, location.packs);
+}
+
+function registerCardContainers(
+  state: DraftState,
+  containers: CardContainer[]
+) {
+  for (const container of containers) {
+    state.packs.set(container.id, container);
+  }
+}

--- a/client/src/parse/parseDraft.ts
+++ b/client/src/parse/parseDraft.ts
@@ -9,9 +9,8 @@ export function parseDraft(
   sourceData: SourceData
 ): ParsedDraft {
   const state = parseInitialState(sourceData);
-  const generator = new TimelineGenerator();
   const { events, isComplete, parseError } =
-      generator.generate(state, sourceData.events);
+      new TimelineGenerator().generate(state, sourceData.events);
 
   annotateCards(state, events);
 
@@ -47,9 +46,12 @@ function annotateCards(
     for (const action of event.actions) {
       if (action.type == 'move-card' && action.subtype == 'pick-card') {
         const card = checkNotNil(cardMap.get(action.card));
-        // TODO: When we clone draft states, this will become a copy rather
-        // than a reference
-        card.pickedIn.push(event);
+        card.pickedIn.push({
+          seat: event.associatedSeat,
+          round: event.round,
+          pick: event.pick,
+          eventId: event.id,
+        });
       }
     }
   }

--- a/client/src/parse/parseInitialState.ts
+++ b/client/src/parse/parseInitialState.ts
@@ -1,108 +1,127 @@
 import { CardContainer, CardPack, DraftCard, DraftSeat, DraftState, PlayerPicks, PackContainer, PACK_LOCATION_UNUSED, PACK_LOCATION_DEAD } from '../draft/DraftState';
 import { SourceCard, SourceData } from './SourceData';
+import { fillDraftStateMaps } from './fillDraftStateMaps';
 
-// TODO: Make this something more than just a static global
-let nextCardId = 0;
-let nextLocationId = 0;
 
 export function parseInitialState(srcData: SourceData): DraftState {
-  let nextPackId = 0;
-  const packMap = new Map<number, CardContainer>();
-  const locationMap = new Map<number, PackContainer>();
+  const state = new StateParser().parse(srcData);
 
-  const state: DraftState = {
-    seats: [],
-    unusedPacks: buildPackLocation(PACK_LOCATION_UNUSED, 'Unused packs'),
-    deadPacks: buildPackLocation(PACK_LOCATION_DEAD, 'Dead packs'),
-    packs: packMap,
-    locations: locationMap,
-  };
-
-  for (const [i, srcSeat] of srcData.seats.entries()) {
-    const playerPicks: PlayerPicks = {
-      id: nextPackId++,
-      type: 'seat',
-      cards: []
-    };
-    packMap.set(playerPicks.id, playerPicks);
-
-    const seat: DraftSeat = {
-      position: i,
-      player: {
-        name: srcSeat.name || FAKE_PLAYER_NAMES[i],
-        seatPosition: i,
-        picks: playerPicks,
-      },
-      originalPacks: [],
-      queuedPacks:
-          buildPackLocation(nextLocationId++, `queuedPacks for seat ${i}`),
-      unopenedPacks:
-          buildPackLocation(nextLocationId++, `unopenedPacks for seat ${i}`),
-    };
-    state.seats.push(seat);
-  }
-
-  for (const [i, srcSeat] of srcData.seats.entries()) {
-    const seat = state.seats[i];
-    for (let j = 1; j < srcSeat.rounds.length; j++) {
-      const pack: CardPack = {
-        id: nextPackId++,
-        type: 'pack',
-        cards: parsePack(srcSeat.rounds[j].packs[0].cards),
-        originalSeat: i,
-        round: j,
-      };
-      seat.unopenedPacks.packs.push(pack);
-      seat.originalPacks.push(pack.id);
-      packMap.set(pack.id, pack);
-    }
-  }
-
-  // Add the extra pack to the unused packs area
-  const extraPack: CardPack = {
-    id: nextPackId++,
-    type: 'pack',
-    cards: parsePack(srcData.extraPack || []),
-    originalSeat: -1,
-    round: -1,
-  };
-  state.unusedPacks.packs.push(extraPack);
-  state.packs.set(extraPack.id, extraPack);
+  fillDraftStateMaps(state);
 
   return state;
 }
 
-function parsePack(srcPack: SourceCard[]) {
-  const pack = [] as DraftCard[];
-  for (let i = 0; i < srcPack.length; i++) {
-    const srcPick = srcPack[i];
-    pack.push({
-      id: nextCardId++,
-      definition: {
-        name: srcPick.name,
-        set: srcPick.edition,
-        collector_number: srcPick.number,
-        cmc: srcPick.cmc,
-        color: srcPick.color,
-        mtgo: srcPick.mtgo || "",
-        tags: srcPick.tags.split(", "),
-        searchName: srcPick.name.toLocaleLowerCase().normalize(),
-      },
-      sourcePackIndex: i,
-      pickedIn: [],
-    });
+class StateParser {
+  private _nextLocationId = 0;
+  private _nextPackId = 0;
+  private _nextCardId = 0;
+
+  parse(srcData: SourceData): DraftState {
+    const packMap = new Map<number, CardContainer>();
+    const locationMap = new Map<number, PackContainer>();
+
+    const state: DraftState = {
+      seats: [],
+      unusedPacks: this.buildPackLocation(PACK_LOCATION_UNUSED, 'Unused packs'),
+      deadPacks: this.buildPackLocation(PACK_LOCATION_DEAD, 'Dead packs'),
+      packs: packMap,
+      locations: locationMap,
+    };
+
+    for (const [i, srcSeat] of srcData.seats.entries()) {
+      const playerPicks: PlayerPicks = {
+        id: this._nextPackId++,
+        type: 'seat',
+        cards: []
+      };
+      packMap.set(playerPicks.id, playerPicks);
+
+      const seat: DraftSeat = {
+        position: i,
+        player: {
+          name: srcSeat.name || FAKE_PLAYER_NAMES[i],
+          seatPosition: i,
+          picks: playerPicks,
+        },
+        originalPacks: [],
+        queuedPacks:
+            this.buildPackLocation(
+                this._nextLocationId++,
+                `queuedPacks for seat ${i}`),
+        unopenedPacks:
+            this.buildPackLocation(
+                this._nextLocationId++,
+                `unopenedPacks for seat ${i}`),
+      };
+      state.seats.push(seat);
+    }
+
+    for (const [i, srcSeat] of srcData.seats.entries()) {
+      const seat = state.seats[i];
+      for (let j = 1; j < srcSeat.rounds.length; j++) {
+        const pack: CardPack = {
+          id: this._nextPackId++,
+          type: 'pack',
+          cards: this.parsePack(srcSeat.rounds[j].packs[0].cards),
+          originalSeat: i,
+          round: j,
+        };
+        seat.unopenedPacks.packs.push(pack);
+        seat.originalPacks.push(pack.id);
+        packMap.set(pack.id, pack);
+      }
+    }
+
+    // Add the extra pack to the unused packs area
+    const extraPack: CardPack = {
+      id: this._nextPackId++,
+      type: 'pack',
+      cards: this.parsePack(srcData.extraPack || []),
+      originalSeat: -1,
+      round: -1,
+    };
+    state.unusedPacks.packs.push(extraPack);
+    state.packs.set(extraPack.id, extraPack);
+
+    return state;
   }
 
-  return pack;
+  private parsePack(srcPack: SourceCard[]) {
+    const pack = [] as DraftCard[];
+    for (let i = 0; i < srcPack.length; i++) {
+      const srcPick = srcPack[i];
+      pack.push({
+        id: this._nextCardId++,
+        definition: {
+          name: srcPick.name,
+          set: srcPick.edition,
+          collector_number: srcPick.number,
+          cmc: srcPick.cmc,
+          color: srcPick.color,
+          mtgo: srcPick.mtgo || "",
+          tags: srcPick.tags.split(", "),
+          searchName: srcPick.name.toLocaleLowerCase().normalize(),
+        },
+        sourcePackIndex: i,
+        pickedIn: [],
+      });
+    }
+
+    return pack;
+  }
+
+  private buildPackLocation(
+      id: number,
+      label: string,
+  ): PackContainer {
+    return {
+      id: id,
+      packs: [],
+      label: label,
+    };
+  }
 }
 
-function buildPackLocation(id: number, label: string): PackContainer {
-  return {
-    id: id,
-    packs: [],
-    label: label,
-  };
-}
 
 const FAKE_PLAYER_NAMES = [
   'Tamanna',

--- a/client/src/ui/replay/controls_row/SearchBox.vue
+++ b/client/src/ui/replay/controls_row/SearchBox.vue
@@ -185,10 +185,10 @@ export default Vue.extend({
               card: card.definition,
               picked: pickEvent != null ? {
                 playerName:
-                    store.draft.seats[pickEvent.associatedSeat]
+                    store.draft.seats[pickEvent.seat]
                         .player.name,
-                seatId: pickEvent.associatedSeat,
-                eventId: pickEvent.id,
+                seatId: pickEvent.seat,
+                eventId: pickEvent.eventId,
                 round: pickEvent.round,
                 pick: pickEvent.pick,
               } : null,


### PR DESCRIPTION
The draft state is essentially two pieces:
[1] The actual state itself
[2] Maps into particular categories of that state. For example, we have
    one map of all the packs in the draft.

These maps need to be generated when the state is first created and
regenerated when the state is cloned. Previously we were doing those steps
in different places, which was causing bugs. Now that's all centralized
into fillDraftStateMaps().

Also makes it so that DraftCard.pickedIn no longer references the
actual event in which it was picked but a data blob that describes the
event. Object references like that don't work well given how we clone the
draft state.