### PR TITLE
Implement /draft/:id endpoint + stub

### DIFF
--- a/client/src/fake_data/devReplayData.ts
+++ b/client/src/fake_data/devReplayData.ts
@@ -1,5 +1,5 @@
 import { SourceData } from '../parse/SourceData';
-import { DRAFT_17 } from './DRAFT_17';
+import { stubDraft_17 } from '../rest/api/draft/draft.17.stub';
 
 /**
  * Precanned data for use during local development
@@ -7,4 +7,5 @@ import { DRAFT_17 } from './DRAFT_17';
  * This file is replaced bt devReplayData.stub.ts for production builds (see
  * /build_config/webpack.prod.js).
  */
-export const devReplayData: SourceData | null = DRAFT_17;
+// TODO: Remove this once we switch over to all-REST endpoints
+export const devReplayData: SourceData | null = stubDraft_17;

--- a/client/src/fetch/fetchEndpoint.ts
+++ b/client/src/fetch/fetchEndpoint.ts
@@ -2,7 +2,6 @@ import axios, { AxiosRequestConfig } from 'axios';
 
 import { RestEndpoint } from '../rest/RestEndpoint';
 import { MixedCollection } from '../util/MixedCollection';
-import { endpoint } from '../rest/endpoint';
 import { DefaultEmpty } from '../util/DefaultEmpty';
 
 export async function fetchEndpoint<T extends RestEndpoint>(

--- a/client/src/rest/api/draft/draft.11.stub.ts
+++ b/client/src/rest/api/draft/draft.11.stub.ts
@@ -1,6 +1,7 @@
-import { SourceData } from '../parse/SourceData';
+import { stub } from '../../stub';
+import { routeDraft } from './draft';
 
-export const DRAFT_11: SourceData = {
+export const stubDraft_11 = stub(routeDraft, {
   "seats":[
     {
       "rounds":[
@@ -7183,4 +7184,4 @@ export const DRAFT_11: SourceData = {
       "round":3
     }
   ]
-};
+});

--- a/client/src/rest/api/draft/draft.17.stub.ts
+++ b/client/src/rest/api/draft/draft.17.stub.ts
@@ -1,6 +1,7 @@
-import { SourceData } from '../parse/SourceData';
+import { stub } from '../../stub';
+import { routeDraft } from './draft';
 
-export const DRAFT_17: SourceData = {
+export const stubDraft_17 = stub(routeDraft, {
   "seats":[
     {
       "rounds":[
@@ -9343,4 +9344,4 @@ export const DRAFT_17: SourceData = {
       "librarian":false
     }
   ]
-}
+});

--- a/client/src/rest/api/draft/draft.ts
+++ b/client/src/rest/api/draft/draft.ts
@@ -1,0 +1,11 @@
+import { endpoint } from '../../endpoint';
+import { SourceData } from '../../../parse/SourceData';
+
+export const routeDraft = endpoint({
+  route: '/api/draft/:id',
+  method: 'get',
+  pathVars: {} as {
+    id: number;
+  },
+  response: {} as SourceData,
+});


### PR DESCRIPTION
Relocates fake data to being next to the endpoint definition.