### PR TITLE
Refactor draft URL management system

### DIFF
--- a/client/src/ui/Replay.vue
+++ b/client/src/ui/Replay.vue
@@ -29,7 +29,7 @@ import { draftStore, DraftStore } from '../state/DraftStore';
 
 import { SourceData } from '../parse/SourceData';
 import { SelectedView } from '../state/selection';
-import { applyReplayUrlState, navTo, parseDraftUrl } from '../router/url_manipulation';
+import { applyReplayUrlState, pushDraftUrlFromState, parseDraftUrl } from '../router/url_manipulation';
 import { globalClickTracker } from './infra/globalClickTracker';
 import { getUserPosition } from '../state/util/userIsSeated';
 import { tuple } from '../util/tuple';
@@ -140,7 +140,7 @@ export default Vue.extend({
         applyReplayUrlState(replayStore, this.$route);
       } else {
         console.log('Syncing URL to state...');
-        navTo(draftStore, replayStore, this.$route, this.$router, {});
+        pushDraftUrlFromState(this, draftStore, replayStore);
       }
       this.isFreshBundle = false;
     },

--- a/client/src/ui/home/Home.vue
+++ b/client/src/ui/home/Home.vue
@@ -59,6 +59,7 @@ import { HomeDraftDescriptor, routeDraftlist } from '../../rest/api/draftlist/dr
 import { fetchEndpoint } from '../../fetch/fetchEndpoint';
 import { FetchStatus } from '../infra/FetchStatus';
 import { ROUTE_JOIN_DRAFT } from '../../rest/api/join/join';
+import { pushDraftUrl } from '../../router/url_manipulation';
 
 export default Vue.extend({
   data() {
@@ -98,7 +99,7 @@ export default Vue.extend({
       // TODO: Error handling
       const response = await fetchEndpoint(ROUTE_JOIN_DRAFT, { id: draftId });
       this.joinFetchStatus = 'loaded';
-      this.$router.push(`/replay/${draftId}`);
+      pushDraftUrl(this, { draftId });
     },
   },
 });

--- a/client/src/ui/replay/CardGrid.vue
+++ b/client/src/ui/replay/CardGrid.vue
@@ -44,7 +44,7 @@ import Vue from 'vue';
 import { DraftCard, DraftPlayer, DraftSeat, CardPack, CardContainer } from '../../draft/DraftState';
 import { TimelineEvent } from '../../draft/TimelineEvent';
 import { SelectedView } from '../../state/selection';
-import { navTo } from '../../router/url_manipulation';
+import { pushDraftUrlRelative } from '../../router/url_manipulation';
 import CardView from './CardView.vue';
 
 import { draftStore, DraftStore } from '../../state/DraftStore';
@@ -178,7 +178,7 @@ export default Vue.extend({
         const adjustedIndex =
             maybeAdjustToStartOfEpoch(replayStore, pick.index);
 
-        navTo(draftStore, replayStore, this.$route, this.$router, {
+        pushDraftUrlRelative(this, {
           eventIndex: adjustedIndex,
           selection: {
             type: 'seat',

--- a/client/src/ui/replay/CardPack.vue
+++ b/client/src/ui/replay/CardPack.vue
@@ -11,7 +11,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { CardPack } from '../../draft/DraftState';
-import { navTo } from '../../router/url_manipulation';
+import { pushDraftUrlRelative } from '../../router/url_manipulation';
 
 import { draftStore } from '../../state/DraftStore';
 import { replayStore } from '../../state/ReplayStore';
@@ -34,7 +34,8 @@ export default Vue.extend({
 
   methods: {
     onClick() {
-      navTo(draftStore, replayStore, this.$route, this.$router, {
+
+      pushDraftUrlRelative(this, {
         selection: {
           type: 'pack',
           id: this.pack.id,

--- a/client/src/ui/replay/ControlsRow.vue
+++ b/client/src/ui/replay/ControlsRow.vue
@@ -37,7 +37,7 @@ import { authStore, AuthStore } from '../../state/AuthStore';
 import { draftStore, DraftStore } from '../../state/DraftStore';
 import { replayStore, ReplayStore } from '../../state/ReplayStore';
 
-import { navTo } from '../../router/url_manipulation';
+import { pushDraftUrlRelative } from '../../router/url_manipulation';
 import { TimelineEvent } from '../../draft/TimelineEvent';
 import { globalClickTracker, UnhandledClickListener } from '../infra/globalClickTracker';
 import { isAuthedUserSelected } from './isAuthedUserSelected';
@@ -77,7 +77,7 @@ export default Vue.extend({
     onPicksClick() {
       const seatId =
           getUserPosition(authStore.user?.id, draftStore.currentState);
-      navTo(draftStore, replayStore, this.$route, this.$router, {
+      pushDraftUrlRelative(this, {
         eventIndex: replayStore.events.length,
         selection: {
           type: 'seat',

--- a/client/src/ui/replay/DraftPicker.vue
+++ b/client/src/ui/replay/DraftPicker.vue
@@ -41,7 +41,6 @@ import { checkNotNil } from '../../util/checkNotNil';
 import { fetchEndpoint } from '../../fetch/fetchEndpoint';
 import { routePick } from '../../rest/api/pick/pick';
 import { delay } from '../../util/delay';
-import { navTo } from '../../router/url_manipulation';
 
 export default Vue.extend({
 

--- a/client/src/ui/replay/DraftSeat.vue
+++ b/client/src/ui/replay/DraftSeat.vue
@@ -37,7 +37,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { DraftSeat } from '../../draft/DraftState';
-import { navTo } from '../../router/url_manipulation';
+import { pushDraftUrlRelative } from '../../router/url_manipulation';
 
 import CardPack from './CardPack.vue';
 
@@ -67,7 +67,7 @@ export default Vue.extend({
 
   methods: {
     onHeaderClick() {
-      navTo(draftStore, replayStore, this.$route, this.$router, {
+      pushDraftUrlRelative(this, {
         selection: {
           type: 'seat',
           id: this.seat.position,

--- a/client/src/ui/replay/PlaybackControls.vue
+++ b/client/src/ui/replay/PlaybackControls.vue
@@ -12,28 +12,28 @@ import Vue from 'vue';
 import { replayStore } from '../../state/ReplayStore';
 import { draftStore } from '../../state/DraftStore';
 
-import { navTo } from '../../router/url_manipulation';
+import { pushDraftUrlRelative, pushDraftUrlFromState } from '../../router/url_manipulation';
 
 export default Vue.extend({
   methods: {
     onNextClick() {
       replayStore.goNext();
-      navTo(draftStore, replayStore, this.$route, this.$router, {});
+      pushDraftUrlFromState(this, draftStore, replayStore);
     },
 
     onPrevClick() {
       replayStore.goBack();
-      navTo(draftStore, replayStore, this.$route, this.$router, {});
+      pushDraftUrlFromState(this, draftStore, replayStore);
     },
 
     onStartClick() {
-      navTo(draftStore, replayStore, this.$route, this.$router, {
+      pushDraftUrlRelative(this, {
         eventIndex: 0,
       });
     },
 
     onEndClick() {
-      navTo(draftStore, replayStore, this.$route, this.$router, {
+      pushDraftUrlRelative(this, {
         eventIndex: replayStore.events.length,
       });
     },

--- a/client/src/ui/replay/PlayerSelector.vue
+++ b/client/src/ui/replay/PlayerSelector.vue
@@ -18,7 +18,6 @@ import { replayStore } from '../../state/ReplayStore';
 import { draftStore } from '../../state/DraftStore';
 
 import { DraftState } from '../../draft/DraftState';
-import { navTo } from '../../router/url_manipulation';
 
 
 export default Vue.extend({
@@ -30,30 +29,6 @@ export default Vue.extend({
   computed: {
     draft(): DraftState {
       return replayStore.draft;
-    },
-  },
-
-  methods: {
-    onNextClick() {
-      replayStore.goNext();
-      navTo(draftStore, replayStore, this.$route, this.$router, {});
-    },
-
-    onPrevClick() {
-      replayStore.goBack();
-      navTo(draftStore, replayStore, this.$route, this.$router, {});
-    },
-
-    onStartClick() {
-      navTo(draftStore, replayStore, this.$route, this.$router, {
-        eventIndex: 0,
-      });
-    },
-
-    onEndClick() {
-      navTo(draftStore, replayStore, this.$route, this.$router, {
-        eventIndex: replayStore.events.length,
-      });
     },
   },
 });

--- a/client/src/ui/replay/controls_row/SearchBox.vue
+++ b/client/src/ui/replay/controls_row/SearchBox.vue
@@ -72,15 +72,15 @@ results.
 
 <script lang="ts">
 import Vue from 'vue';
+import { replayStore } from '../../../state/ReplayStore';
+import { draftStore } from '../../../state/DraftStore';
+
 import { CardContainer, MtgCard } from '../../../draft/DraftState';
-import { navTo } from '../../../router/url_manipulation';
+import { pushDraftUrlRelative } from '../../../router/url_manipulation';
 import { SelectedView } from '../../../state/selection';
 import { indexOf } from '../../../util/collection';
 import { TimelineEvent, TimelineAction } from '../../../draft/TimelineEvent';
 import { globalClickTracker, UnhandledClickListener } from '../../infra/globalClickTracker';
-
-import { replayStore } from '../../../state/ReplayStore';
-import { draftStore } from '../../../state/DraftStore';
 import { CardLocation } from '../../../state/DeckBuilderModule';
 
 export default Vue.extend({
@@ -142,7 +142,7 @@ export default Vue.extend({
 
     onCardNameClick(result: CardSearchResult) {
       if (result.packType != 'shadow-realm') {
-        navTo(draftStore, replayStore, this.$route, this.$router, {
+        pushDraftUrlRelative(this, {
           selection: {
             id: result.packId,
             type: result.packType,
@@ -155,7 +155,7 @@ export default Vue.extend({
       if (pick != null) {
         const index = indexOf(replayStore.events, { id: pick.eventId });
         if (index != -1) {
-          navTo(draftStore, replayStore, this.$route, this.$router, {
+          pushDraftUrlRelative(this, {
             eventIndex: index,
             selection: {
               id: pick.fromSeat,

--- a/client/src/ui/replay/controls_row/TimelineSelector.vue
+++ b/client/src/ui/replay/controls_row/TimelineSelector.vue
@@ -86,7 +86,7 @@ import Vue from 'vue';
 import { replayStore } from '../../../state/ReplayStore';
 import { draftStore } from '../../../state/DraftStore';
 
-import { navTo } from '../../../router/url_manipulation';
+import { pushDraftUrlRelative, pushDraftUrlFromState } from '../../../router/url_manipulation';
 import { isPickEvent } from '../../../state/util/isPickEvent';
 import { eventToString } from '../../../state/util/eventToString';
 import { indexOf } from '../../../util/collection';
@@ -102,7 +102,7 @@ export default Vue.extend({
 
       set(value) {
         replayStore.setTimeMode(value ? 'synchronized' : 'original');
-        navTo(draftStore, replayStore, this.$route, this.$router, {});
+        pushDraftUrlFromState(this, draftStore, replayStore);
       }
     },
 
@@ -124,7 +124,7 @@ export default Vue.extend({
     onSyncPickClicked(eventId: number) {
       const index = indexOf(replayStore.events, { id: eventId });
       if (index != -1) {
-        navTo(draftStore, replayStore, this.$route, this.$router, {
+        pushDraftUrlRelative(this, {
           eventIndex: index,
         });
       } else {
@@ -135,7 +135,7 @@ export default Vue.extend({
     onTempPickClicked(eventId: number, seatId: number) {
       const index = indexOf(replayStore.events, { id: eventId });
       if (index != -1) {
-        navTo(draftStore, replayStore, this.$route, this.$router, {
+        pushDraftUrlRelative(this, {
           eventIndex: index,
           selection: {
             type: 'seat',


### PR DESCRIPTION
Unify logic for parsing and modifying draft URLs. Now, you can do three
things:

- pushDraftUrl: Navigate to the URL specified
- pushDraftUrlRelative: Modify the existing URL in the specified way and
  then nav to it. This method is relative to the existing URL; the old
  version was relative to the current data store state.
- pushDraftUrlFromState: Modifies the existing URL to match the current
  data store state.