### PR TITLE
Fix dominant color logic

### DIFF
--- a/client/src/parse/TimelineGenerator.ts
+++ b/client/src/parse/TimelineGenerator.ts
@@ -357,37 +357,37 @@ function buildIncrementPickedColorsAction(
   };
 
   for (let gainedCard of gainedCards) {
-    if (gainedCard.colors.includes('W')) {
+    if (gainedCard.color_identity.includes('W')) {
       action.w++;
     }
-    if (gainedCard.colors.includes('U')) {
+    if (gainedCard.color_identity.includes('U')) {
       action.u++;
     }
-    if (gainedCard.colors.includes('B')) {
+    if (gainedCard.color_identity.includes('B')) {
       action.b++;
     }
-    if (gainedCard.colors.includes('R')) {
+    if (gainedCard.color_identity.includes('R')) {
       action.r++;
     }
-    if (gainedCard.colors.includes('G')) {
+    if (gainedCard.color_identity.includes('G')) {
       action.g++;
     }
   }
 
   for (let gainedCard of lostCards) {
-    if (gainedCard.colors.includes('W')) {
+    if (gainedCard.color_identity.includes('W')) {
       action.w--;
     }
-    if (gainedCard.colors.includes('U')) {
+    if (gainedCard.color_identity.includes('U')) {
       action.u--;
     }
-    if (gainedCard.colors.includes('B')) {
+    if (gainedCard.color_identity.includes('B')) {
       action.b--;
     }
-    if (gainedCard.colors.includes('R')) {
+    if (gainedCard.color_identity.includes('R')) {
       action.r--;
     }
-    if (gainedCard.colors.includes('G')) {
+    if (gainedCard.color_identity.includes('G')) {
       action.g--;
     }
   }

--- a/client/src/ui/replay/player_selector/DraftSeat.vue
+++ b/client/src/ui/replay/player_selector/DraftSeat.vue
@@ -103,32 +103,43 @@ export default Vue.extend({
       return [
         {
           color: 'W' as const,
+          defaultIndex: 0,
           weight: this.generateColorWeight(this.seat.colorCounts.w, totalPicks),
           src: WManaSmall,
         },
         {
           color: 'U' as const,
+          defaultIndex: 1,
           weight: this.generateColorWeight(this.seat.colorCounts.u, totalPicks),
           src: UManaSmall,
         },
         {
           color: 'B' as const,
+          defaultIndex: 2,
           weight: this.generateColorWeight(this.seat.colorCounts.b, totalPicks),
           src: BManaSmall,
         },
         {
           color: 'R' as const,
+          defaultIndex: 3,
           weight: this.generateColorWeight(this.seat.colorCounts.r, totalPicks),
           src: RManaSmall,
         },
         {
           color: 'G' as const,
+          defaultIndex: 4,
           weight: this.generateColorWeight(this.seat.colorCounts.g, totalPicks),
           src: GManaSmall,
         },
       ]
       .filter(colorWeight => colorWeight.weight > 0)
-      .sort((a, b) => a.weight - b.weight);
+      .sort((a, b) => {
+        let cmp = b.weight - a.weight;
+        if (cmp == 0) {
+          cmp = a.defaultIndex - b.defaultIndex;
+        }
+        return cmp;
+      });
     },
   },
 
@@ -151,7 +162,7 @@ export default Vue.extend({
     },
 
     generateColorWeight(pickCount: number, totalPickCount: number) {
-      if (pickCount < 2 || pickCount / totalPickCount < 0.11) {
+      if (pickCount < 2 || pickCount / totalPickCount < 0.16) {
         return 0;
       } else {
         return pickCount;
@@ -163,6 +174,7 @@ export default Vue.extend({
 
 interface ColorWeight {
   color: ScryfallColor;
+  defaultIndex: number,
   weight: number;
   src: string;
 }


### PR DESCRIPTION
- Use color identity instead of just color
- Sort icons in proper order (most common to least common)
- Increase threshold for min color count