### PR TITLE
Fix eslint plugin integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,9 @@
     "source.fixAll": "explicit"
   },
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+
+  // Points the ESLint VSCode extension to the correct location of our
+  // eslint.config.ts
+  "eslint.workingDirectories": ["./client"]
 }


### PR DESCRIPTION
The VSCode ESLint plugin can't automatically locate eslint config files in non-root folders; we have to specify which working directories to use.