### PR TITLE
GitHub Actions Workflows for docker build & push to GHCR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -32,13 +32,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.REGISTRY_TOKEN }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
 
       - name: Extract Metadata
         id: metadata
@@ -46,7 +48,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
           tags: |
-            type=ref,event=branch,prefix=
+            type=ref,event=branch
             type=ref,event=tag
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
@@ -75,10 +77,10 @@ jobs:
           provenance: true
           github-token: ${{ secrets.REGISTRY_TOKEN }}
 
-      # - name: Sign the image with GitHub OIDC token
-      #   if: github.event_name != 'pull_request'
-      #   uses: actions/attest-build-provenance@v2
-      #   with:
-      #     subject-name: ${{ env.REGISTRY }}/r38-${{ inputs.image-name }}
-      #     subject-digest: ${{ steps.build-image.outputs.digest }}
-      #     push-to-registry: true
+      - name: Sign the image with GitHub OIDC token
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
+          subject-digest: ${{ steps.build-image.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,7 +54,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
           tags: |
-            type=raw,value=latest,enable=true
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
         id: setup-builder

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -52,7 +52,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/r38-${{ inputs.image-name }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -76,8 +76,8 @@ jobs:
             ${{ steps.metadata.outputs.tags}}
           labels: |
             ${{ steps.metadata.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/r38-${{ inputs.image-name }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/r38-${{ inputs.image-name }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache,mode=max
           provenance: mode=min
           github-token: ${{ secrets.REGISTRY_TOKEN }}
 
@@ -85,6 +85,6 @@ jobs:
         if: github.event_name != 'pull_request' && inputs.create-attestation == true
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/r38-${{ inputs.image-name }}
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
           subject-digest: ${{ steps.build-image.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,6 +11,11 @@ on:
         required: true
         type: string
         description: "Docker build target (e.g. go_deploy or filter_deploy)"
+      create-attestation:
+        required: false
+        type: boolean
+        default: false
+        description: "Whether to create a container attestation for the image"
     outputs:
       image-digest:
         description: "The digest of the published container image"
@@ -77,7 +82,7 @@ jobs:
           github-token: ${{ secrets.REGISTRY_TOKEN }}
 
       - name: Generate Container Attestation
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && inputs.create-attestation == true
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/r38-${{ inputs.image-name }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -47,11 +47,10 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/r38-${{ inputs.image-name }}
           tags: |
             type=ref,event=branch
             type=ref,event=tag
-            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
@@ -72,25 +71,15 @@ jobs:
             ${{ steps.metadata.outputs.tags}}
           labels: |
             ${{ steps.metadata.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache,mode=max
-          sbom: true
-          provenance: mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/r38-${{ inputs.image-name }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/r38-${{ inputs.image-name }}:buildcache,mode=max
+          provenance: mode=min
           github-token: ${{ secrets.REGISTRY_TOKEN }}
 
       - name: Generate Container Attestation
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/r38-${{ inputs.image-name }}
           subject-digest: ${{ steps.build-image.outputs.digest }}
-          push-to-registry: true
-
-      - name: Generate SBOM Attestation
-        if: github.event_name != 'pull_request'
-        uses: actions/attest-sbom@v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
-          subject-digest: ${{ steps.build-image.outputs.digest }}
-          sbom-path: "sbom.json"
           push-to-registry: true

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -56,6 +56,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,6 +26,7 @@ jobs:
       packages: write
       id-token: write
       actions: read
+      attestations: write
     outputs:
       digest: ${{ steps.build-image.outputs.digest }}
 
@@ -74,13 +75,22 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache,mode=max
           sbom: true
-          provenance: true
+          provenance: mode=max
           github-token: ${{ secrets.REGISTRY_TOKEN }}
 
-      - name: Sign the image with GitHub OIDC token
+      - name: Generate Container Attestation
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
           subject-digest: ${{ steps.build-image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate SBOM Attestation
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
+          subject-digest: ${{ steps.build-image.outputs.digest }}
+          sbom-path: "sbom.json"
           push-to-registry: true

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -34,9 +34,9 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: r38-${{ inputs.image-name }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-r38-${{ inputs.image-name }}
           tags: |
-            type=ref,event=branch
+            type=ref,event=branch,prefix=
             type=ref,event=tag
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,9 +54,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=true
 
       - name: Set up Docker Buildx
         id: setup-builder

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -56,7 +56,6 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
-            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -34,7 +34,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}-r38-${{ inputs.image-name }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-${{ inputs.image-name }}
           tags: |
             type=ref,event=branch,prefix=
             type=ref,event=tag
@@ -59,10 +59,11 @@ jobs:
             ${{ steps.metadata.outputs.tags}}
           labels: |
             ${{ steps.metadata.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-r38-${{ inputs.image-name }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-r38-${{ inputs.image-name }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-${{ inputs.image-name }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-${{ inputs.image-name }}:buildcache,mode=max
           sbom: true
           provenance: true
+          github-token: ${{ secrets.REGISTRY_TOKEN }}
 
       # - name: Sign the image with GitHub OIDC token
       #   if: github.event_name != 'pull_request'

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -30,11 +30,21 @@ jobs:
       digest: ${{ steps.build-image.outputs.digest }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract Metadata
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}-${{ inputs.image-name }}
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}
           tags: |
             type=ref,event=branch,prefix=
             type=ref,event=tag
@@ -59,8 +69,8 @@ jobs:
             ${{ steps.metadata.outputs.tags}}
           labels: |
             ${{ steps.metadata.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-${{ inputs.image-name }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-${{ inputs.image-name }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache,mode=max
           sbom: true
           provenance: true
           github-token: ${{ secrets.REGISTRY_TOKEN }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,73 @@
+name: Reusable Docker Build and Push
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        required: true
+        type: string
+        description: "Name of the image (e.g. app or filter)"
+      target:
+        required: true
+        type: string
+        description: "Docker build target (e.g. go_deploy or filter_deploy)"
+    outputs:
+      image-digest:
+        description: "The digest of the published container image"
+        value: ${{ jobs.build.outputs.digest }}
+    env:
+      REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      actions: read
+    outputs:
+      digest: ${{ steps.build-image.outputs.digest }}
+
+    steps:
+      - name: Extract Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: r38-${{ inputs.image-name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        id: setup-builder
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: true
+          version: latest
+
+      - name: Build and push image
+        id: build-image
+        uses: docker/build-push-action@v6
+        with:
+          builder: ${{ steps.setup-builder.outputs.name }}
+          push: ${{ github.event_name != 'pull_request' }}
+          target: ${{ inputs.target }}
+          tags: |
+            ${{ steps.metadata.outputs.tags}}
+          labels: |
+            ${{ steps.metadata.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-r38-${{ inputs.image-name }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}-r38-${{ inputs.image-name }}:buildcache,mode=max
+          sbom: true
+          provenance: true
+
+      # - name: Sign the image with GitHub OIDC token
+      #   if: github.event_name != 'pull_request'
+      #   uses: actions/attest-build-provenance@v2
+      #   with:
+      #     subject-name: ${{ env.REGISTRY }}/r38-${{ inputs.image-name }}
+      #     subject-digest: ${{ steps.build-image.outputs.digest }}
+      #     push-to-registry: true

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -15,12 +15,12 @@ on:
       image-digest:
         description: "The digest of the published container image"
         value: ${{ jobs.build.outputs.digest }}
-    env:
-      REGISTRY: ghcr.io
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
+          username: walkingeyerobot
           password: ${{ secrets.REGISTRY_TOKEN }}
 
       - name: Extract Metadata

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -78,7 +78,8 @@ jobs:
             ${{ steps.metadata.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ inputs.image-name }}:buildcache,mode=max
-          provenance: mode=min
+          provenance: mode=max
+          sbom: true
           github-token: ${{ secrets.REGISTRY_TOKEN }}
 
       - name: Generate Container Attestation

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -12,26 +12,27 @@ on:
 
 jobs:
   build:
-
+    concurrency:
+      group: "client"
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Setup node
-      uses: actions/setup-node@v4
-      with:
-        node-version: 23.x
-        cache: 'npm'
-        cache-dependency-path: '**/package-lock.json'
-    - name: Install deps
-      run: npm ci
-      working-directory: ./client
-    - name: Build
-      run: npm run build
-      working-directory: ./client
-    - name: Lint
-      run: npx eslint .
-      working-directory: ./client
-    - name: Format
-      run: npx prettier . --check
-      working-directory: ./client
+      - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23.x
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+      - name: Install deps
+        run: npm ci
+        working-directory: ./client
+      - name: Build
+        run: npm run build
+        working-directory: ./client
+      - name: Lint
+        run: npx eslint .
+        working-directory: ./client
+      - name: Format
+        run: npx prettier . --check
+        working-directory: ./client

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Build Caller
+name: Docker BuildBuild Caller
 
 on:
   push:
@@ -9,9 +9,6 @@ on:
   pull_request:
     branches:
       - main
-
-env:
-  REGISTRY: ghcr.io
 
 jobs:
   setup:
@@ -39,3 +36,6 @@ jobs:
       image-name: filter
       target: filter_deploy
     secrets: inherit
+
+  env:
+    REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,20 +11,7 @@ on:
       - main
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    env:
-      REGISTRY: ghcr.io
-    steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
-
   build-app:
-    needs: setup
     uses: ./.github/workflows/build-image.yml
     with:
       image-name: app
@@ -32,7 +19,6 @@ jobs:
     secrets: inherit
 
   build-filter:
-    needs: setup
     uses: ./.github/workflows/build-image.yml
     with:
       image-name: filter

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,7 +10,12 @@ on:
     branches:
       - main
   workflow_dispatch:
-
+    inputs:
+      create-attestation:
+        description: "Create attestation for the built images"
+        type: boolean
+        required: false
+        default: false
 jobs:
   build-app:
     uses: ./.github/workflows/build-image.yml

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,41 @@
+name: Build Caller
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+  build-app:
+    needs: setup
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image-name: app
+      target: go_deploy
+    secrets: inherit
+
+  build-filter:
+    needs: setup
+    uses: ./.github/workflows/build-image.yml
+    with:
+      image-name: filter
+      target: filter_deploy
+    secrets: inherit

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Docker BuildBuild Caller
+name: Docker Build Caller
 
 on:
   push:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   setup:
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -36,6 +38,3 @@ jobs:
       image-name: filter
       target: filter_deploy
     secrets: inherit
-
-  env:
-    REGISTRY: ghcr.io

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
 
   build-app:
     needs: setup

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build-app:
@@ -16,6 +17,7 @@ jobs:
     with:
       image-name: app
       target: go_deploy
+      create-attestation: true
     secrets: inherit
 
   build-filter:
@@ -23,4 +25,5 @@ jobs:
     with:
       image-name: filter
       target: filter_deploy
+      create-attestation: true
     secrets: inherit

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       image-name: app
       target: go_deploy
-      create-attestation: true
+      create-attestation: ${{ github.event_name == 'workflow_dispatch' && inputs.create-attestation || false }}
     secrets: inherit
 
   build-filter:
@@ -30,5 +30,5 @@ jobs:
     with:
       image-name: filter
       target: filter_deploy
-      create-attestation: true
+      create-attestation: ${{ github.event_name == 'workflow_dispatch' && inputs.create-attestation || false }}
     secrets: inherit

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -10,31 +10,32 @@ on:
       - main
       - master
     paths:
-      - '**.go'
+      - "**.go"
 
 jobs:
-
   build:
+    concurrency:
+      group: "server"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.23.6'
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.23.6"
 
-    - name: Install ObjectBox
-      run: bash <(curl -s https://raw.githubusercontent.com/objectbox/objectbox-go/main/install.sh)
+      - name: Install ObjectBox
+        run: bash <(curl -s https://raw.githubusercontent.com/objectbox/objectbox-go/main/install.sh)
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v ./...
 
-    - name: Run fuzzers
-      uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@2b38b4142d7fa5dde3823e60a358c28ed17635df # v0.1.3
-      with:
-        fuzz-time: 2m
-        fail-fast: true
+      - name: Run fuzzers
+        uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@2b38b4142d7fa5dde3823e60a358c28ed17635df # v0.1.3
+        with:
+          fuzz-time: 2m
+          fail-fast: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,14 +4,14 @@ services:
       context: .
       dockerfile: Dockerfile
       target: filter_deploy
-    image: git.ninefives.online/cdanis/r38-filter:latest
+    image: ghcr.io/dabrames/r38-filter:latest
     volumes:
       - &socket socket:/srv/r38/socket
     working_dir: /srv/r38/socket
     restart: always
 
   app:
-    image: git.ninefives.online/cdanis/r38-app:latest
+    image: ghcr.io/dabrames/r38-app:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,14 +4,14 @@ services:
       context: .
       dockerfile: Dockerfile
       target: filter_deploy
-    image: ghcr.io/dabrames/r38-filter:latest
+    image: ghcr.io/dabrames/r38/filter:latest
     volumes:
       - &socket socket:/srv/r38/socket
     working_dir: /srv/r38/socket
     restart: always
 
   app:
-    image: ghcr.io/dabrames/r38-app:latest
+    image: ghcr.io/dabrames/r38/app:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,14 +4,14 @@ services:
       context: .
       dockerfile: Dockerfile
       target: filter_deploy
-    image: ghcr.io/dabrames/r38/filter:latest
+    image: ghcr.io/walkingeyerobot/r38/filter:latest
     volumes:
       - &socket socket:/srv/r38/socket
     working_dir: /srv/r38/socket
     restart: always
 
   app:
-    image: ghcr.io/dabrames/r38/app:latest
+    image: ghcr.io/walkingeyerobot/r38/app:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This PR adds Actions Workflows to build on push to main.

**Features**
1. `latest` tag will only update on pushes to main
2. Builds from git tags or branches will have their own docker tag available for testing
3. Build Attestation available as an option (disabled by default)
4. docker build cache included for both filter & app images

**Requirements to get this working upstream**
1. Mitch needs to add a repo secret REGISTRY_TOKEN to upstream repo with a PAT which gives the proper permissions for publishing packages.
2. Mitch needs to update package permissions after they're published to inherit the repo settings
3. Update the repo settings to allow us to push/pull from his ghcr on the upstream repo