### PR TITLE
skips creating spectator channel for in-person draft, and makes error…

### DIFF
--- a/main.go
+++ b/main.go
@@ -942,7 +942,7 @@ func doJoinSeat(ob *objectbox.ObjectBox, userId int64, draft *schema.Draft, seat
 		})
 	}
 
-	return err
+	return nil
 }
 
 // ServeAPISkip serves the /api/skip endpoint.
@@ -2303,12 +2303,14 @@ func ArchiveSpectatorChannels(ob *objectbox.ObjectBox) error {
 					schema.Result_.Timestamp.LessOrEqual(threeDaysAgo)).Count()
 				if resultsCount == 24 {
 					channelId := draft.SpectatorChannelId
-					draft.SpectatorChannelId = ""
-					log.Printf("locking channel %s", channelId)
-					err = dg.ChannelPermissionSet(channelId, EveryoneRole, 0, 0, discordgo.PermissionViewChannel)
-					if err != nil {
-						log.Printf("error archiving spectator channels: %s", err.Error())
-						return err
+					if len(channelId) > 0 {
+						draft.SpectatorChannelId = ""
+						log.Printf("locking channel %s", channelId)
+						err = dg.ChannelPermissionSet(channelId, EveryoneRole, 0, 0, discordgo.PermissionViewChannel)
+						if err != nil {
+							log.Printf("error archiving spectator channels: %s", err.Error())
+							return err
+						}
 					}
 				}
 			}

--- a/makedraft/makedraft.go
+++ b/makedraft/makedraft.go
@@ -240,7 +240,7 @@ func MakeDraft(settings Settings, ob *objectbox.ObjectBox) error {
 
 	var dg *discordgo.Session
 	botToken := os.Getenv("DISCORD_BOT_TOKEN")
-	if !*settings.Simulate && len(botToken) > 0 {
+	if !*settings.Simulate && !*settings.InPerson && len(botToken) > 0 {
 		dg, err = discordgo.New("Bot " + botToken)
 		if err != nil {
 			return fmt.Errorf("error creating spectator channel: %v", err)


### PR DESCRIPTION
… locking spectator channel for joining users non-fatal