### PR TITLE
sort cards alphabetically for tag writer

### DIFF
--- a/draftconfig/draftconfig.go
+++ b/draftconfig/draftconfig.go
@@ -1,8 +1,10 @@
 package draftconfig
 
 import (
+	"cmp"
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strings"
 )
 
@@ -101,6 +103,9 @@ func GetCards(cfg DraftConfig) ([]Card, error) {
 		if err != nil {
 			return nil, err
 		}
+		slices.SortFunc(cubeCobraList.Cards.Mainboard, func(a, b CubeCobraCard) int {
+			return cmp.Compare(a.Details.Name, b.Details.Name)
+		})
 		for _, cubeCobraCard := range cubeCobraList.Cards.Mainboard {
 			images := []string{cubeCobraCard.Details.ImageNormal}
 			if len(cubeCobraCard.Details.ImageFlip) > 0 {


### PR DESCRIPTION
Fetching CubeCobra JSON data no longer respects the default sort of the cube. This means that the tag writer doesn't present the cards in alphabetical order, and instead it sorts by color and mana value.

I raised the issue again with CubeCobra but fixing it on our end would be more robust.

Please review this. I didn't test it at all. I just kind of edited the code in the github web ui. I'm not even sure it compiles.